### PR TITLE
Fixed bug filling rolesSelected array in users.create

### DIFF
--- a/resources/views/manage/users/create.blade.php
+++ b/resources/views/manage/users/create.blade.php
@@ -64,7 +64,7 @@
       el: '#app',
       data: {
         auto_password: true,
-        rolesSelected: {!! old('roles') ? old('roles') : '[]' !!}
+        rolesSelected: [{!! old('roles') ? old('roles') : '' !!}]
       }
     });
   </script>


### PR DESCRIPTION
{!! old('roles') !!} returns plain value e.g. 3,4,5. It must be wrapped within [ ] that is [3, 4, 5] before being assigned to rolesSelected.