### PR TITLE
Removed LaratrustServiceProvider already discovery by Laravel 5.5

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -176,11 +176,6 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
-        /*
-         * Third Party Service Providers...
-         */
-        Laratrust\LaratrustServiceProvider::class,
-
     ],
 
     /*


### PR DESCRIPTION
Laratrust 4 [already support](https://github.com/santigarcor/laratrust/blob/4.0/composer.json#L43-L52) Laravel 5.5 package discovery