### PR TITLE
[Bug Fix] Role Plural when validating a new role

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -41,7 +41,7 @@ class RoleController extends Controller
     {
       $this->validateWith([
         'display_name' => 'required|max:255',
-        'name' => 'required|max:100|alpha_dash|unique:role,name',
+        'name' => 'required|max:100|alpha_dash|unique:roles',
         'description' => 'sometimes|max:255'
       ]);
 


### PR DESCRIPTION
Fix a bug that wasn't allowing us to create a new role: was a misspelling `roles`.

Also, remove the `column` option `name`, as it matches the field. Docs: [rule unique](https://laravel.com/docs/5.5/validation#rule-unique)