### PR TITLE
[Refactory] Use unsigned{column_type} methods

### DIFF
--- a/database/migrations/2017_10_25_190625_create_posts_table.php
+++ b/database/migrations/2017_10_25_190625_create_posts_table.php
@@ -16,13 +16,13 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
             $table->string('slug')->unique();
-            $table->integer('author_id')->unsigned();
+            $table->unsignedInteger('author_id');
             $table->string('title');
             $table->text('excerpt');
             $table->longText('content');
             $table->integer('status')->default(1);
-            $table->integer('type')->unsigned()->default(1);
-            $table->bigInteger('comment_count')->unsigned()->default(0);
+            $table->unsignedInteger('type')->default(1);
+            $table->unsignedBigInteger('comment_count')->default(0);
             $table->dateTime('published_at');
             $table->timestamps();
 


### PR DESCRIPTION
Use `unsigned{column_type}` methods in post's migration.

Docs: https://laravel.com/docs/master/migrations#columns