### PR TITLE
Use str_random() instead of bin2hex(openssl_random_pseudo_bytes())

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -14,6 +14,6 @@ class UserObserver
      */
     public function creating(User $user)
     {
-      $user->api_token = bin2hex(openssl_random_pseudo_bytes(30));
+        $user->api_token = str_random(60);
     }
 }

--- a/database/seeds/LaratrustSeeder.php
+++ b/database/seeds/LaratrustSeeder.php
@@ -58,7 +58,7 @@ class LaratrustSeeder extends Seeder
                 'name' => ucwords(str_replace("_", " ", $key)),
                 'email' => $key.'@app.com',
                 'password' => bcrypt('password'),
-                'api_token' => bin2hex(openssl_random_pseudo_bytes(30))
+                'api_token' => str_random(60),
             ]);
             $user->attachRole($role);
         }


### PR DESCRIPTION
Instead of calling an additional method to generate tokens, why don't use [Laravel `str_random` helper method](https://laravel.com/docs/master/helpers#method-str-random)?

`str_random` uses PHP 7 [`random_bytes`](https://secure.php.net/manual/en/function.random-bytes.php). `random_bytes` is new in PHP 7 as the native always-available PHP method to generate random bytes, which chooses its internal source of randomness depending on the platform it's on.